### PR TITLE
fix(render): render year or month/year

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -178,7 +178,9 @@ const t = (key: string, minimumDuration = null): string => {
 
 const emit = defineEmits([
   "render-next-month",
+  "render-next-year",
   "render-previous-month",
+  "render-previous-year",
   "select-booking-date",
   "update:checkIn",
   "update:checkOut",
@@ -388,6 +390,10 @@ const currentYear: ComputedRef<number> = computed(() => {
   return months.value[activeIndex.value].yearKey;
 });
 
+const currentMonth: ComputedRef<number> = computed(
+  () => months.value[activeIndex.value].monthKey + 1
+);
+
 const disabledPagination: ComputedRef<{ left: boolean; right: boolean }> =
   computed(() => {
     const diff = props.showYear ? 12 : 2;
@@ -403,11 +409,15 @@ const paginate = (operator: string) => {
 
   if (activeIndex.value > 0 && operator === "-") {
     activeIndex.value -= count;
-    emit("render-previous-month", currentYear.value);
+    props.showYear
+      ? emit("render-previous-year", currentYear.value)
+      : emit("render-previous-month", currentMonth.value, currentYear.value);
   }
   if (operator === "+") {
     activeIndex.value += count;
-    emit("render-next-month", currentYear.value);
+    props.showYear
+      ? emit("render-next-year", currentYear.value)
+      : emit("render-next-month", currentMonth.value, currentYear.value);
   }
 };
 


### PR DESCRIPTION
- Si `showYear = false` : 
  - Previous button clicked : `emit('render-previous-month')` avec `currentMonth` et `currentYear` en params
  - Next button clicked : `emit('render-next-month')` avec `currentMonth` et `currentYear` en params
- Si `showYear = true` :
  - Previous button clicked : `emit('render-previous-year')` avec `currentYear` en params
  - Next button clicked : `emit('render-next-year')` avec `currentYear` en params